### PR TITLE
Add render scheduler to allow usage of refs.

### DIFF
--- a/src/rx/react-render-scheduler.js
+++ b/src/rx/react-render-scheduler.js
@@ -1,0 +1,109 @@
+var Rx = require('rx');
+function __extends(d, b) {
+  for (var p in b) {
+    if (b.hasOwnProperty(p)) {
+      d[p] = b[p];
+    }
+  }
+  function __() {
+    this.constructor = d;
+  }
+
+  d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+
+module.exports = (function MakeReactRenderScheduler(__super__) {
+  function ReactRenderScheduler() {
+    __super__.call(this);
+    this.scheduled = {};
+    this._lastId = -1;
+    this.scheduledReadySubject = new Rx.Subject();
+  }
+
+  __extends(ReactRenderScheduler, __super__);
+
+  function ScheduledIdDisposable(scheduled, id) {
+    this.scheduled = scheduled;
+    this.id = id;
+    this.isDisposed = false;
+    this.actionDisposable = null;
+    this.hasNew = false;
+  }
+
+  ScheduledIdDisposable.prototype.dispose = function dispose() {
+    if (!this.isDisposed) {
+      this.isDiposed = true;
+      delete this.scheduled[this.id];
+    }
+  };
+
+  ReactRenderScheduler.prototype.runScheduled = function runScheduled() {
+    if (!this.hasNew) {
+      return;
+    }
+    this.hasNew = false;
+    var scheduled = this.scheduled;
+    this.scheduled = {};
+
+    // Keep in mind that scheduled actions can be disposed of while processing
+    // in this loop
+    var keys = Object.keys(scheduled);
+    var length = keys.length;
+    for (var i = 0; i < length; ++i) {
+      var work = scheduled[keys[i]];
+      if (work) {
+        try {
+          work();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    }
+  };
+
+  ReactRenderScheduler.prototype.scheduleAction =
+    function scheduleAction(disposable, action, scheduler, state, id) {
+      this.scheduled[id] = function schedule() {
+        if (!disposable.isDiposed) {
+          disposable.setDisposable(Rx.Disposable._fixup(action(scheduler, state)));
+        }
+      };
+
+      this.hasNew = true;
+      this.scheduledReadySubject.onNext(id);
+    };
+
+  ReactRenderScheduler.prototype.schedule = function schedule(state, action) {
+    var id = ++this._lastId;
+    var disposable = new Rx.SingleAssignmentDisposable();
+    this.scheduleAction(disposable, action, this, state, id);
+    var scheduledIdDisposable = new ScheduledIdDisposable(this.scheduled, id);
+
+    return Rx.Disposable.create(function dispose() {
+      disposable.dispose();
+      scheduledIdDisposable.dispose();
+    });
+  };
+
+  ReactRenderScheduler.prototype._scheduleFuture = function _scheduleFuture(state, dueTime, action) {
+    if (dueTime === 0) {
+      return this.schedule(state, action);
+    }
+
+    var id = ++this._lastId;
+    var disposable = new Rx.SingleAssignmentDisposable();
+
+    var timeoutHandle = setTimeout(function delayedSchedule() {
+      this.scheduleAction(disposable, action, this, state, id);
+    }, dueTime);
+    var scheduledIdDisposable = new ScheduledIdDisposable(this.scheduled, id);
+
+    return Rx.Disposable.create(function dispose() {
+      disposable.dispose();
+      scheduledIdDisposable.dispose();
+      clearTimeout(timeoutHandle);
+    });
+  };
+
+  return ReactRenderScheduler;
+}(Rx.Scheduler));

--- a/src/rx/react-render-scheduler.js
+++ b/src/rx/react-render-scheduler.js
@@ -93,8 +93,9 @@ module.exports = (function MakeReactRenderScheduler(__super__) {
     var id = ++this._lastId;
     var disposable = new Rx.SingleAssignmentDisposable();
 
+    var self = this;
     var timeoutHandle = setTimeout(function delayedSchedule() {
-      this.scheduleAction(disposable, action, this, state, id);
+      self.scheduleAction(disposable, action, this, state, id);
     }, dueTime);
     var scheduledIdDisposable = new ScheduledIdDisposable(this.scheduled, id);
 

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -455,6 +455,8 @@ describe('Component', function () {
   it('should accept vtree as function and "ref"', function (done) {
     let vtreeController$ = Rx.Observable.range(0, 2).controlled();
     // Make simple custom element
+
+    let renderSubject = new Rx.Subject();
     let MyElement = Cycle.component('MyElement', function (_1, _2, self) {
       vtreeController$.subscribe(() => {
         let editField = ReactDOM.findDOMNode(self.refs.theRef);
@@ -462,12 +464,16 @@ describe('Component', function () {
         assert.strictEqual(editField.tagName, 'H3');
         done();
       });
-      return Rx.Observable.just(() =>
+      return renderSubject.delay(0, self.scheduler).map(() =>
         <h3 className="myelementclass"
             ref="theRef" />
       );
     });
+
     applyToDOM(createRenderTarget(), MyElement);
+    renderSubject.onNext(null);
+    renderSubject.onNext(null);
+
     // Make assertions
     vtreeController$.request(1);
   });


### PR DESCRIPTION
Unfortunately, despite what the README says, refs do not work in the latest version of cycle-react.  I should clarify -- they work on the very first ReactDOM.render call, but any other onNext that invokes a set state will build react elements outside of the render context, thus throwing an error.

First, check the test I modified.  If you remove my scheduler from the test (removing the .delay call) the test will fail, thus demonstrating the problem.  

The fix is not "perfect", but it was a elegant a solution as I could find.  It's "opt in".  If you want refs, you will need to attach a delay(0, component.scheduler) before the JSX rendering with the refs.  The scheduler will essentially do what the vtree function was doing, by "capturing" the vtree context and allowing it to be invoked within the render call.

Let me know what you think about this approach.  I need some working ref code, so I am forced to use my branch until we can agree on a fix for master.