### PR TITLE
(fix) Interaction listeners called with multiple arguments

### DIFF
--- a/src/rx/event-subject.js
+++ b/src/rx/event-subject.js
@@ -3,8 +3,8 @@ var Rx = require('rx');
 
 function createEventSubject() {
   var subject = new Rx.Subject();
-  subject.onEvent = function onEvent(value) {
-    subject.onNext(value);
+  subject.onEvent = function onEvent() {
+    subject.onNext.apply(subject, Array.prototype.slice.call(arguments));
   };
   return subject;
 }


### PR DESCRIPTION
This PR allows any `interactions.listener` to be passed multiple arguments, a requirement I faced when wanting to use the great [`react-autosuggest`](https://github.com/moroshko/react-autosuggest) library.
